### PR TITLE
Fix failing build on macOS

### DIFF
--- a/src/publisher/openwrt.rs
+++ b/src/publisher/openwrt.rs
@@ -186,8 +186,8 @@ fn fs() -> Option<Vec<proto::FileSystem>> {
     r.push(proto::FileSystem {
         path:      "/".into(),
         blocksize: s.block_size().into(),
-        total:     s.blocks(),
-        free:      s.blocks_free(),
+        total:     s.blocks().into(),
+        free:      s.blocks_free().into(),
     });
 
     Some(r)


### PR DESCRIPTION
Build fails on macOS x64 because of some wrong integer size.
```
error[E0308]: mismatched types
   --> src/publisher/openwrt.rs:189:20
    |
189 |         total:     s.blocks(),
    |                    ^^^^^^^^^^ expected u64, found u32

error[E0308]: mismatched types
   --> src/publisher/openwrt.rs:190:20
    |
190 |         free:      s.blocks_free(),
    |                    ^^^^^^^^^^^^^^^ expected u64, found u32
```
I guess just converting there should be fine? Fixes it for me tho.